### PR TITLE
feat: add Toss Payments approval demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+client/node_modules/
+client/package-lock.json
+server/target/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # toss-payments-approval-demo
+
+Toss Payments 결제 위젯 v2를 이용해 결제 요청 후 서버에서 승인하는 최소 예제입니다.
+
+- `/client`: React 프론트엔드
+- `/server`: Spring Boot 서버
+
+각 디렉터리의 README를 참고하여 실행하세요.

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,4 @@
+# 프론트에서 사용할 테스트용 클라이언트 키
+VITE_TOSS_CLIENT_KEY=테스트용_클라이언트키
+# 결제 승인 API를 호출할 서버 주소
+VITE_API_BASE_URL=http://localhost:8080

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,19 @@
+# 프론트엔드 실행 방법
+
+이 예제는 Toss Payments 결제 위젯 v2를 사용하는 React 애플리케이션입니다.
+
+## 환경 변수 설정
+
+```bash
+cp .env.example .env
+# 각 키 값을 실제 테스트 키로 변경
+```
+
+## 실행
+
+```bash
+npm i
+npm run dev
+```
+
+브라우저에서 [http://localhost:5173](http://localhost:5173)를 열어 테스트합니다.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Toss Payments Approval Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "toss-payments-approval-client",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "@tosspayments/payment-widget-sdk": "^0.12.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/client/src/components/Checkout.jsx
+++ b/client/src/components/Checkout.jsx
@@ -1,0 +1,42 @@
+// 결제 버튼을 제공하고 Toss 위젯을 호출하는 컴포넌트
+import { useState } from 'react';
+import { loadWidget } from '../lib/toss';
+
+export default function Checkout() {
+  const [loading, setLoading] = useState(false);
+
+  const handlePay = async () => {
+    setLoading(true);
+    // 1) 주문번호와 금액을 준비한다.
+    const orderId = crypto.randomUUID();
+    const amount = 1500; // 테스트용 금액
+
+    // 2) Toss 결제 위젯을 로드하고 결제창을 띄운다.
+    const tossPayments = await loadWidget();
+    const paymentWidget = tossPayments.widgets({ customerKey: 'anonymous' });
+    paymentWidget.renderPaymentMethods('#payment-method', { value: amount });
+    paymentWidget.renderAgreement('#agreement');
+
+    // 3) 결제를 요청하면 Toss가 successUrl 또는 failUrl로 이동시킨다.
+    await paymentWidget.requestPayment({
+      orderId,
+      amount,
+      orderName: '테스트 주문',
+      successUrl: `${window.location.origin}/success`,
+      failUrl: `${window.location.origin}/fail`,
+    });
+    setLoading(false);
+  };
+
+  return (
+    <div>
+      <h1>Toss Payments 예제</h1>
+      {/* 결제수단과 약관이 렌더링될 영역 */}
+      <div id="payment-method" />
+      <div id="agreement" />
+      <button onClick={handlePay} disabled={loading}>
+        {loading ? '처리 중...' : '결제하기'}
+      </button>
+    </div>
+  );
+}

--- a/client/src/lib/toss.js
+++ b/client/src/lib/toss.js
@@ -1,0 +1,10 @@
+// Toss 결제 위젯 로더를 분리하여 관리한다.
+import { loadTossPayments } from '@tosspayments/payment-widget-sdk';
+
+/**
+ * 클라이언트 키를 사용하여 Toss Payments 객체를 로드한다.
+ */
+export async function loadWidget() {
+  const clientKey = import.meta.env.VITE_TOSS_CLIENT_KEY;
+  return await loadTossPayments(clientKey);
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,20 @@
+// 앱의 진입점: 라우팅을 설정한다.
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Checkout from './components/Checkout';
+import Success from './pages/Success';
+import Fail from './pages/Fail';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    {/* 간단한 라우터 구성 */}
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Checkout />} />
+        <Route path="/success" element={<Success />} />
+        <Route path="/fail" element={<Fail />} />
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/client/src/pages/Fail.jsx
+++ b/client/src/pages/Fail.jsx
@@ -1,0 +1,13 @@
+// 결제 실패 시 오류 정보를 보여주는 페이지
+export default function Fail() {
+  const params = new URLSearchParams(window.location.search);
+  const message = params.get('message');
+  const code = params.get('code');
+  return (
+    <div>
+      <h2>결제 실패</h2>
+      <p>{message}</p>
+      <p>코드: {code}</p>
+    </div>
+  );
+}

--- a/client/src/pages/Success.jsx
+++ b/client/src/pages/Success.jsx
@@ -1,0 +1,48 @@
+// 결제 후 successUrl로 돌아왔을 때 서버로 승인 요청을 보내는 페이지
+import { useEffect, useState } from 'react';
+
+export default function Success() {
+  const [result, setResult] = useState(null);
+  const params = new URLSearchParams(window.location.search);
+  const paymentKey = params.get('paymentKey');
+  const orderId = params.get('orderId');
+  const amount = params.get('amount');
+
+  useEffect(() => {
+    // 서버에 결제 승인을 요청한다.
+    async function confirm() {
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_API_BASE_URL}/api/payments/confirm`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ paymentKey, orderId, amount: Number(amount) }),
+          }
+        );
+        const data = await res.json();
+        setResult(data);
+      } catch (e) {
+        setResult({ error: e.message });
+      }
+    }
+    confirm();
+  }, [paymentKey, orderId, amount]);
+
+  if (!result) return <p>승인 요청 중...</p>;
+  if (result.error || result.code)
+    return (
+      <div>
+        <h2>결제 승인 실패</h2>
+        <p>{result.message || result.error}</p>
+      </div>
+    );
+
+  return (
+    <div>
+      <h2>결제 성공</h2>
+      {/* 승인 결과를 그대로 출력하여 확인한다. */}
+      <pre>{JSON.stringify(result, null, 2)}</pre>
+    </div>
+  );
+}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Vite 기본 설정에 React 플러그인 추가
+export default defineConfig({
+  plugins: [react()],
+});

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,22 @@
+# 서버 실행 방법
+
+Spring Boot로 구성된 간단한 결제 승인 서버입니다.
+
+## 환경 변수 설정
+
+```bash
+export TOSS_SECRET_KEY=테스트용_시크릿키
+export TOSS_API_BASE=https://api.tosspayments.com
+```
+
+## 실행
+
+```bash
+mvn spring-boot:run
+```
+
+## 테스트
+
+```bash
+mvn test
+```

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>toss-payments-approval-server</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>toss-payments-approval-server</name>
+  <properties>
+    <java.version>17</java.version>
+    <spring.boot.version>3.2.5</spring.boot.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+      <version>${spring.boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>${spring.boot.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/server/src/main/java/com/example/payment/ConfirmController.java
+++ b/server/src/main/java/com/example/payment/ConfirmController.java
@@ -1,0 +1,35 @@
+// 결제 승인 요청을 받아 TossApprovalClient로 전달하는 컨트롤러
+package com.example.payment;
+
+import com.example.payment.dto.ConfirmRequest;
+import com.example.payment.dto.ConfirmResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@RestController
+@RequestMapping("/api/payments")
+@CrossOrigin(origins = "http://localhost:5173") // 프론트에서 접근 허용
+public class ConfirmController {
+  private final TossApprovalClient client;
+
+  public ConfirmController(TossApprovalClient client) {
+    this.client = client;
+  }
+
+  @PostMapping("/confirm")
+  public ResponseEntity<?> confirm(@RequestBody ConfirmRequest request) {
+    try {
+      // 서버에서 Toss 승인 API를 호출하여 응답을 전달한다.
+      ConfirmResponse response = client.confirm(request);
+      return ResponseEntity.ok(response);
+    } catch (WebClientResponseException e) {
+      // Toss에서 내려준 에러 바디를 그대로 반환한다.
+      return ResponseEntity.status(e.getStatusCode()).body(e.getResponseBodyAsString());
+    }
+  }
+}

--- a/server/src/main/java/com/example/payment/TossApprovalClient.java
+++ b/server/src/main/java/com/example/payment/TossApprovalClient.java
@@ -1,0 +1,42 @@
+// 서버에서 Toss 승인 API를 호출하는 클라이언트
+package com.example.payment;
+
+import com.example.payment.dto.ConfirmRequest;
+import com.example.payment.dto.ConfirmResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class TossApprovalClient {
+  private final WebClient webClient;
+
+  public TossApprovalClient(
+      @Value("${TOSS_API_BASE:https://api.tosspayments.com}") String apiBase,
+      @Value("${TOSS_SECRET_KEY}") String secretKey) {
+    String basicAuth = Base64.getEncoder()
+        .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+    this.webClient = WebClient.builder()
+        .baseUrl(apiBase)
+        .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth)
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .build();
+  }
+
+  /**
+   * Toss 결제 승인 API를 호출한다. 이 과정은 서버에서만 수행되어야 하므로
+   * 시크릿 키가 프론트에 노출되지 않는다.
+   */
+  public ConfirmResponse confirm(ConfirmRequest request) {
+    return webClient.post()
+        .uri("/v1/payments/confirm")
+        .bodyValue(request)
+        .retrieve()
+        .bodyToMono(ConfirmResponse.class)
+        .block();
+  }
+}

--- a/server/src/main/java/com/example/payment/dto/ConfirmRequest.java
+++ b/server/src/main/java/com/example/payment/dto/ConfirmRequest.java
@@ -1,0 +1,8 @@
+// Toss 결제 승인 요청 본문
+package com.example.payment.dto;
+
+public record ConfirmRequest(
+    String paymentKey,
+    String orderId,
+    Long amount
+) {}

--- a/server/src/main/java/com/example/payment/dto/ConfirmResponse.java
+++ b/server/src/main/java/com/example/payment/dto/ConfirmResponse.java
@@ -1,0 +1,10 @@
+// Toss 승인 API 응답의 일부 필드를 담는 DTO
+package com.example.payment.dto;
+
+public record ConfirmResponse(
+    String paymentKey,
+    String orderId,
+    String orderName,
+    Long totalAmount,
+    String status
+) {}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8080


### PR DESCRIPTION
## Summary
- 토스 결제 위젯 v2 및 성공/실패 페이지를 사용하여 React 예제 구현 
- 스프링 부트 서버 호출 던지기 지불 확인 API를 추가하십시오 
- 환경 샘플 및 실행 지침을 제공합니다

## Testing
- `pnpm test`
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689beece7e008328af80c4db9c7ab04d